### PR TITLE
Pull 1.0 release of hmp_client from IGS repo, use symlink not alias.

### DIFF
--- a/docker/chiron-core/Dockerfile
+++ b/docker/chiron-core/Dockerfile
@@ -29,7 +29,7 @@ ENV LANG C.UTF-8
 
 RUN pip3 install boto
 
-RUN wget -O /opt/hmp_client.zip https://github.com/jmatsumura/hmp_client/archive/master.zip
+RUN wget -O /opt/hmp_client.zip https://github.com/IGS/hmp_client/archive/v1.0.zip
 RUN unzip -d /opt/hmp_client /opt/hmp_client.zip
-ENV PATH /opt/hmp_client/hmp_client-master/bin:$PATH
-RUN echo 'alias hmp_client="client.py"' >> ~/.bashrc
+RUN ln -s /opt/hmp_client/hmp_client-1.0/bin/client.py /usr/local/bin/hmp_client
+


### PR DESCRIPTION
Modify Dockerfile to:

* pull official 1.0 release of hmp_client from IGS GitHub repo
* symlink hmp_client into /usr/local/bin instead of using a bash alias
